### PR TITLE
Fix hero overlap spacing, add mobile hamburger nav, and update home content

### DIFF
--- a/client/src/components/home/FAQ.tsx
+++ b/client/src/components/home/FAQ.tsx
@@ -12,6 +12,10 @@ export function FAQ() {
       answer: "Qwalo is an AI-powered qualitative research platform that helps teams conduct in-depth user research through voice-based interviews. It enables marketers, product managers, and research teams to test ideas, validate products, and gather rich consumer insights—faster and at scale."
     },
     {
+      question: "Which languages does Qwalo support?",
+      answer: "Qwalo is built with India in mind. The platform supports multiple Indian languages, allowing you to conduct research in respondents’ native languages for more authentic and accurate insights. Language support will continue to expand over time."
+    },
+    {
       question: "How does AI voice-based interviewing work?",
       answer: "Qwalo uses AI to conduct natural, conversational interviews with respondents via voice. The AI asks adaptive follow-up questions based on responses, just like a skilled human interviewer, helping uncover deeper insights without requiring live moderation."
     },
@@ -44,10 +48,6 @@ export function FAQ() {
           </ul>
         </div>
       )
-    },
-    {
-      question: "Which languages does Qwalo support?",
-      answer: "Qwalo is built with India in mind. The platform supports multiple Indian languages, allowing you to conduct research in respondents’ native languages for more authentic and accurate insights. Language support will continue to expand over time."
     },
     {
       question: "How is Qwalo different from surveys or traditional interviews?",

--- a/client/src/components/home/Features.tsx
+++ b/client/src/components/home/Features.tsx
@@ -1,27 +1,27 @@
 import { Card } from "@/components/ui/card";
-import { Sparkles, Zap, RefreshCw, BarChart3 } from "lucide-react";
+import { AudioWaveform, Languages, Lightbulb, SearchCheck } from "lucide-react";
 
 export function Features() {
   const features = [
     {
-      icon: <Zap className="w-6 h-6 text-brand-purple" />,
-      title: "Power Dialer",
-      description: "Dial 10x faster with automated workflows."
+      icon: <AudioWaveform className="w-6 h-6 text-brand-purple" />,
+      title: "Dynamic Probing",
+      description: "AI that asks adaptive follow-ups to dig deeper into why."
     },
     {
-      icon: <Sparkles className="w-6 h-6 text-brand-purple" />,
-      title: "AI Transcription",
-      description: "Real-time call summaries & action items."
+      icon: <Languages className="w-6 h-6 text-brand-purple" />,
+      title: "Multilingual AI",
+      description: "Support for multiple local languages for authentic insights."
     },
     {
-      icon: <RefreshCw className="w-6 h-6 text-brand-purple" />,
-      title: "CRM Sync",
-      description: "Auto-push notes to HubSpot & Salesforce."
+      icon: <Lightbulb className="w-6 h-6 text-brand-purple" />,
+      title: "Instant Themes",
+      description: "Automatically identifies recurring patterns across large datasets."
     },
     {
-      icon: <BarChart3 className="w-6 h-6 text-brand-purple" />,
-      title: "Analytics",
-      description: "Track connect rates & team performance."
+      icon: <SearchCheck className="w-6 h-6 text-brand-purple" />,
+      title: "Traceable Insights",
+      description: "Every finding links back to the original voice evidence."
     }
   ];
 
@@ -30,17 +30,15 @@ export function Features() {
       <div className="container mx-auto max-w-6xl">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {features.map((feature, index) => (
-            <Card 
-              key={index} 
+            <Card
+              key={index}
               className="p-6 bg-white/80 backdrop-blur-md border border-white/50 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 rounded-2xl group"
             >
               <div className="w-12 h-12 rounded-xl bg-brand-purple/10 flex items-center justify-center mb-4 group-hover:bg-brand-purple/20 transition-colors">
                 {feature.icon}
               </div>
               <h3 className="font-bold text-gray-900 mb-2">{feature.title}</h3>
-              <p className="text-sm text-gray-600 leading-relaxed">
-                {feature.description}
-              </p>
+              <p className="text-sm text-gray-600 leading-relaxed">{feature.description}</p>
             </Card>
           ))}
         </div>

--- a/client/src/components/home/Hero.tsx
+++ b/client/src/components/home/Hero.tsx
@@ -5,69 +5,51 @@ import { MockupLeft, MinorCards } from "./ProductMockups";
 export function Hero() {
   return (
     <section className="relative min-h-[100vh] w-full overflow-hidden bg-white pt-32 pb-48 flex items-center justify-center">
-      
-      {/* Background Shape */}
       <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
-        <div 
-            className="absolute top-[-10%] left-[-10%] w-[120%] h-[95%] rounded-[0%_0%_50%_50%/0%_0%_30%_30%] bg-gradient-to-b from-[#FDF4F5] via-[#FFF0F5] to-[#ffe4e6] opacity-80"
-            style={{
-                background: "radial-gradient(ellipse at top, #ffe4e6 0%, #fff1f2 60%, #fff0f5 100%)"
-            }}
+        <div
+          className="absolute top-[-10%] left-[-10%] w-[120%] h-[95%] rounded-[0%_0%_50%_50%/0%_0%_30%_30%] bg-gradient-to-b from-[#FDF4F5] via-[#FFF0F5] to-[#ffe4e6] opacity-80"
+          style={{ background: "radial-gradient(ellipse at top, #ede9fe 0%, #f5f3ff 60%, #fff0f5 100%)" }}
         />
-        {/* Subtle decorative blob */}
         <div className="absolute top-[10%] right-[10%] w-[500px] h-[500px] bg-purple-200/20 rounded-full blur-3xl" />
       </div>
 
       <div className="relative z-10 container mx-auto px-4 text-center max-w-5xl">
-        
-        {/* Mockups positioned absolute relative to container */}
         <div className="relative w-full h-full min-h-[400px]">
-            <MockupLeft />
-            <MinorCards />
-            
-            {/* Main Content */}
-            <div className="flex flex-col items-center justify-center max-w-3xl mx-auto space-y-8 mt-10 relative z-20">
-            
+          <MockupLeft />
+          <MinorCards />
+
+          <div className="flex flex-col items-center justify-center max-w-4xl mx-auto space-y-8 mt-10 relative z-20 px-4 md:px-10 xl:px-36">
             <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight text-gray-900 leading-[1.1]">
-                Boost Your Connect Rates by <span className="text-brand-purple">10x</span>
-                <br />
-                with our AI Automated Dialer
+              Capture the "Why" with <span className="text-brand-purple">AI-Powered Voice Interviews</span>
             </h1>
-            
-            <p className="text-lg md:text-xl text-gray-600 max-w-2xl mx-auto leading-relaxed">
-                Transcribe live calls with AI and push notes to your CRM.
-                <br className="hidden md:block" />
-                Get back 10 hours of your time every week.
+
+            <p className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+              Conduct in-depth, multilingual qualitative research at scale. Qwalo uses AI to ask adaptive follow-up
+              questions, uncovering rich consumer insights in minutes.
             </p>
 
             <div className="flex flex-col sm:flex-row items-center gap-4 pt-4">
-                <Button variant="outline" className="h-14 px-8 rounded-full text-lg font-semibold border-2 border-white bg-white/50 backdrop-blur-sm hover:bg-white text-gray-900 shadow-sm transition-all hover:scale-105 cursor-pointer">
+              <Button variant="outline" className="h-14 px-8 rounded-full text-lg font-semibold border-2 border-white bg-white/50 backdrop-blur-sm hover:bg-white text-gray-900 shadow-sm transition-all hover:scale-105 cursor-pointer">
                 Schedule Demo
-                </Button>
-                <Button className="h-14 px-8 rounded-full text-lg font-semibold bg-brand-purple hover:bg-brand-purple-dark text-white shadow-xl shadow-brand-purple/20 transition-all hover:scale-105 group cursor-pointer">
-                Try For Free
+              </Button>
+              <Button className="h-14 px-8 rounded-full text-lg font-semibold bg-brand-purple hover:bg-brand-purple-dark text-white shadow-xl shadow-brand-purple/20 transition-all hover:scale-105 group cursor-pointer">
+                Start Your Study
                 <ChevronRight className="w-5 h-5 ml-1 group-hover:translate-x-1 transition-transform" />
-                </Button>
+              </Button>
             </div>
 
-            {/* Social Proof */}
             <div className="flex flex-col items-center gap-3 pt-12">
-                <div className="flex -space-x-3">
+              <div className="flex -space-x-3">
                 {[1, 2, 3].map((i) => (
-                    <div key={i} className="w-10 h-10 rounded-full border-2 border-white overflow-hidden bg-gray-200">
-                    <img 
-                        src={`https://i.pravatar.cc/100?img=${i + 10}`} 
-                        alt="User" 
-                        className="w-full h-full object-cover"
-                    />
-                    </div>
+                  <div key={i} className="w-10 h-10 rounded-full border-2 border-white overflow-hidden bg-gray-200" />
                 ))}
-                </div>
-                <p className="text-sm font-medium text-gray-500">
-                Join hundreds of other B2B sales teams and agencies
-                </p>
+              </div>
+              <div className="flex items-center gap-1 text-sm text-gray-600">
+                <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+                <span className="font-semibold">Trusted by research and product teams across India</span>
+              </div>
             </div>
-            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/client/src/components/home/HowItWorks.tsx
+++ b/client/src/components/home/HowItWorks.tsx
@@ -1,0 +1,49 @@
+const steps = [
+  {
+    title: "Design & Launch",
+    points: [
+      "Define Your Goals: Fully customize your interview scripts, logic, and research objectives to match your project.",
+      "Rapid Setup: Most studies can be configured and launched within minutes, eliminating long planning cycles.",
+      "Invite Respondents: Simply share a link or invite your target audience to participate from any device."
+    ]
+  },
+  {
+    title: "AI-Powered Interviewing",
+    points: [
+      "Natural Conversations: Qwalo’s AI conducts natural, voice-based interviews that feel like a skilled human moderator.",
+      "Dynamic Probing: The AI asks adaptive follow-up questions in real-time to dig deeper into why.",
+      "Multilingual Reach: Conduct interviews in multiple Indian languages to capture authentic, regional nuances."
+    ]
+  },
+  {
+    title: "Analyze & Act",
+    points: [
+      "Instant Synthesis: Automatically transcribes, organizes, and identifies recurring themes across all interviews.",
+      "Traceable Evidence: Every insight or summary is linked directly back to the original voice recording.",
+      "Shareable Reports: Receive structured highlights and key themes your team can act on immediately."
+    ]
+  }
+];
+
+export function HowItWorks() {
+  return (
+    <section className="bg-white py-20 px-4">
+      <div className="container mx-auto max-w-6xl">
+        <h2 className="text-4xl font-bold text-center text-gray-900 mb-12 tracking-tight">From Setup to Insights in Minutes</h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          {steps.map((step, idx) => (
+            <div key={step.title} className="rounded-2xl border border-purple-100 bg-gradient-to-b from-purple-50/50 to-white p-6">
+              <div className="text-sm font-semibold text-brand-purple mb-2">Step {idx + 1}</div>
+              <h3 className="text-xl font-bold text-gray-900 mb-3">{step.title}</h3>
+              <ul className="space-y-2 text-sm text-gray-600">
+                {step.points.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/home/ProductMockups.tsx
+++ b/client/src/components/home/ProductMockups.tsx
@@ -1,29 +1,22 @@
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { User, MoreHorizontal, Zap, Sparkles, Activity, CheckCircle } from "lucide-react";
+import { Languages, Lightbulb, Search, AudioWaveform, Link2 } from "lucide-react";
 
 export function MockupLeft() {
   return (
-    <Card className="w-[300px] bg-white shadow-xl rounded-xl border border-gray-100 overflow-hidden absolute left-[-150px] top-24 opacity-90 rotate-[-4deg] hover:rotate-0 transition-transform duration-500 hidden xl:block z-10">
+    <Card className="w-[340px] bg-white shadow-xl rounded-xl border border-gray-100 overflow-hidden absolute left-[-150px] top-24 opacity-95 rotate-[-4deg] hover:rotate-0 transition-transform duration-500 hidden xl:block z-10">
       <div className="p-4 border-b bg-gray-50 flex items-center justify-between">
-        <div className="text-xs font-semibold text-gray-500 uppercase">Recent Dials</div>
-        <MoreHorizontal className="w-4 h-4 text-gray-400" />
+        <div className="text-xs font-semibold text-gray-500 uppercase">Live Interview Mockup</div>
+        <Badge variant="secondary" className="text-[10px] bg-brand-purple/10 text-brand-purple">In Progress</Badge>
       </div>
-      <div className="divide-y">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="p-4 flex items-center gap-3 hover:bg-gray-50 transition-colors">
-            <div className="w-8 h-8 rounded-full bg-brand-purple/10 flex items-center justify-center text-brand-purple">
-              <User className="w-4 h-4" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium truncate">Prospect {i}</div>
-              <div className="text-xs text-gray-500">Called 2m ago</div>
-            </div>
-            <Badge variant="secondary" className="text-[10px] bg-green-50 text-green-600">
-              Connected
-            </Badge>
-          </div>
-        ))}
+      <div className="p-4 space-y-3 text-left">
+        <div className="text-xs text-gray-500">Respondent: Bengaluru, Kannada speaker</div>
+        <div className="rounded-lg bg-gray-50 p-3 text-sm text-gray-700">
+          <span className="font-semibold">User:</span> "The checkout is fast, but I am not fully sure about delivery timelines."
+        </div>
+        <div className="rounded-lg bg-brand-purple/5 border border-brand-purple/20 p-3 text-sm text-gray-700">
+          <span className="font-semibold text-brand-purple">AI Deep-dive follow-up:</span> "What made delivery trust a concern, and what proof would make you confident to complete your order?"
+        </div>
       </div>
     </Card>
   );
@@ -32,49 +25,35 @@ export function MockupLeft() {
 export function MinorCards() {
   return (
     <>
-      {/* Top Right Floating Card - Speed */}
-      <Card className="absolute right-[5%] top-[20%] w-48 p-4 bg-white/90 backdrop-blur-md shadow-lg border border-white/50 rounded-2xl hidden lg:block rotate-[6deg] hover:rotate-0 transition-all duration-500 z-10 animate-in fade-in slide-in-from-bottom-8 duration-700 delay-300">
+      <Card className="absolute right-[5%] top-[20%] w-52 p-4 bg-white/90 backdrop-blur-md shadow-lg border border-white/50 rounded-2xl hidden lg:block rotate-[6deg] hover:rotate-0 transition-all duration-500 z-10">
         <div className="flex items-center gap-3 mb-2">
-            <div className="w-8 h-8 rounded-full bg-orange-100 flex items-center justify-center text-orange-600">
-                <Zap className="w-4 h-4" />
-            </div>
-            <div>
-                <div className="text-xs font-semibold text-gray-500 uppercase">Speed</div>
-                <div className="text-sm font-bold text-gray-900">10x Faster</div>
-            </div>
-        </div>
-        <div className="h-1.5 w-full bg-gray-100 rounded-full overflow-hidden">
-            <div className="h-full bg-orange-500 w-[85%]" />
+          <div className="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center text-brand-purple">
+            <AudioWaveform className="w-4 h-4" />
+          </div>
+          <div>
+            <div className="text-xs font-semibold text-gray-500 uppercase">Voice Analysis</div>
+            <div className="text-sm font-bold text-gray-900">Dynamic Probing Active</div>
+          </div>
         </div>
       </Card>
 
-      {/* Right Middle - AI Status */}
-      <Card className="absolute right-[-20px] top-[45%] w-56 p-4 bg-white/95 backdrop-blur-md shadow-xl border border-white/50 rounded-2xl hidden lg:block rotate-[-3deg] hover:rotate-0 transition-all duration-500 z-10 animate-in fade-in slide-in-from-bottom-8 duration-700 delay-500">
-         <div className="flex items-start gap-3">
-            <div className="w-8 h-8 rounded-full bg-brand-purple flex items-center justify-center text-white shadow-lg shadow-brand-purple/30">
-                <Sparkles className="w-4 h-4" />
-            </div>
-            <div className="flex-1">
-                <div className="text-sm font-bold text-gray-900 mb-1">AI Assistant</div>
-                <div className="text-xs text-gray-500 leading-tight">Transcribing call notes & updating CRM...</div>
-                <div className="flex items-center gap-2 mt-2">
-                    <span className="flex h-2 w-2 rounded-full bg-green-500 animate-pulse" />
-                    <span className="text-[10px] font-medium text-green-600">Active</span>
-                </div>
-            </div>
-         </div>
+      <Card className="absolute right-[-20px] top-[45%] w-60 p-4 bg-white/95 backdrop-blur-md shadow-xl border border-white/50 rounded-2xl hidden lg:block rotate-[-3deg] hover:rotate-0 transition-all duration-500 z-10">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-bold text-gray-900">
+            <Lightbulb className="w-4 h-4 text-amber-500" /> Instant Themes
+          </div>
+          <div className="text-xs text-gray-500">Affordability, Delivery Trust, and Product Durability surfaced across interviews.</div>
+        </div>
       </Card>
 
-      {/* Bottom Right - Analytics */}
-      <Card className="absolute right-[10%] bottom-[25%] w-40 p-3 bg-white/90 backdrop-blur-md shadow-lg border border-white/50 rounded-2xl hidden xl:block rotate-[4deg] hover:rotate-0 transition-all duration-500 z-10 animate-in fade-in slide-in-from-bottom-8 duration-700 delay-700">
-         <div className="flex items-center justify-between mb-2">
-             <div className="text-[10px] font-semibold text-gray-500">Connect Rate</div>
-             <Activity className="w-3 h-3 text-green-500" />
-         </div>
-         <div className="text-2xl font-bold text-gray-900 mb-1">28%</div>
-         <div className="text-[10px] text-green-600 flex items-center gap-1">
-             <CheckCircle className="w-3 h-3" /> +12% this week
-         </div>
+      <Card className="absolute right-[10%] bottom-[25%] w-56 p-3 bg-white/90 backdrop-blur-md shadow-lg border border-white/50 rounded-2xl hidden xl:block rotate-[4deg] hover:rotate-0 transition-all duration-500 z-10">
+        <div className="flex items-center gap-2 text-[10px] font-semibold text-gray-600 mb-2">
+          <Link2 className="w-3 h-3 text-brand-purple" /> Evidence Linking
+        </div>
+        <div className="space-y-1 text-xs text-gray-600">
+          <div className="flex items-center gap-2"><Search className="w-3 h-3 text-gray-400" /> Insight mapped to source clip #14</div>
+          <div className="flex items-center gap-2"><Languages className="w-3 h-3 text-gray-400" /> Hindi, Tamil, Marathi supported</div>
+        </div>
       </Card>
     </>
   );

--- a/client/src/components/home/Solutions.tsx
+++ b/client/src/components/home/Solutions.tsx
@@ -1,0 +1,59 @@
+import { Card } from "@/components/ui/card";
+
+const topGroups = [
+  { title: "Product", items: ["Features", "How It Works", "Languages Supported", "Security"] },
+  { title: "Solutions", items: ["For Marketers", "For Product Managers", "For UX & Research", "For Startups"] },
+  { title: "Resources", items: ["Blog", "Research Playbooks", "FAQs"] }
+];
+
+const personas = [
+  {
+    title: "For Product Managers",
+    description: "Validate Features and User Needs at the Speed of Your Sprint.",
+  },
+  {
+    title: "For Marketers",
+    description: "Understand your real customer in every language they speak.",
+  },
+  {
+    title: "For UX & Research",
+    description: "Run in-depth interviews at scale without manual moderation bottlenecks.",
+  },
+  {
+    title: "For Startups",
+    description: "Launch and validate product ideas quickly with traceable voice evidence.",
+  },
+];
+
+export function Solutions() {
+  return (
+    <section className="py-20 px-4 bg-gray-50/60">
+      <div className="container mx-auto max-w-6xl space-y-10">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {topGroups.map((group) => (
+            <Card key={group.title} className="p-6 rounded-2xl border border-gray-200 shadow-sm">
+              <h3 className="text-lg font-bold text-gray-900 mb-3">{group.title}</h3>
+              <ul className="text-sm text-gray-600 space-y-1">
+                {group.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </Card>
+          ))}
+        </div>
+
+        <div>
+          <h2 className="text-4xl font-bold text-center text-gray-900 mb-10 tracking-tight">Solutions</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {personas.map((persona) => (
+              <Card key={persona.title} className="p-6 rounded-2xl border border-gray-200 shadow-sm">
+                <h3 className="text-xl font-bold text-gray-900 mb-2">{persona.title}</h3>
+                <p className="text-gray-600 text-sm">{persona.description}</p>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -1,85 +1,63 @@
 import { Link } from "wouter";
+import { Linkedin } from "lucide-react";
 import logoUrl from "@assets/logo.png";
 
 export function Footer() {
   return (
     <footer className="bg-white pt-20 pb-10 border-t border-gray-100">
       <div className="container mx-auto px-4 max-w-6xl">
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-8 mb-16">
-          
-          {/* Brand Column - Spans 2 cols on large screens */}
-          <div className="col-span-2 lg:col-span-2 space-y-4 pr-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8 mb-16">
+          <div className="space-y-4 pr-8">
             <Link href="/" className="inline-block">
-                <img 
-                  src={logoUrl} 
-                  alt="Qwalo AI" 
-                  className="h-10 w-auto object-contain" 
-                />
+              <img src={logoUrl} alt="Qwalo AI" className="h-10 w-auto object-contain" />
             </Link>
             <p className="text-gray-600 text-sm leading-relaxed max-w-xs">
-              AI-powered qualitative research through voice-based interviews
+              AI-powered qualitative research through multilingual voice interviews.
             </p>
+            <a href="#" className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-brand-purple transition-colors">
+              <Linkedin className="w-4 h-4" /> LinkedIn
+            </a>
           </div>
 
-          {/* Product Column */}
           <div className="space-y-4">
             <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Product</h4>
             <ul className="space-y-3 text-gray-600 text-sm">
-               {/* Column contents removed as requested */}
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Features</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Pricing</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Use Cases</a></li>
             </ul>
           </div>
 
-          {/* Solutions Column */}
           <div className="space-y-4">
             <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Solutions</h4>
             <ul className="space-y-3 text-gray-600 text-sm">
-               {/* Column contents removed as requested */}
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Marketers</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">PMs</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">UX Teams</a></li>
             </ul>
           </div>
 
-          {/* Resources Column */}
           <div className="space-y-4">
-            <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Resources</h4>
+            <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Company</h4>
             <ul className="space-y-3 text-gray-600 text-sm">
-               {/* Column contents removed as requested */}
+              <li><a href="#" className="hover:text-brand-purple transition-colors">About Us</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Contact</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Careers</a></li>
             </ul>
           </div>
 
-          {/* Company Column */}
           <div className="space-y-4">
-             <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Company</h4>
-             <ul className="space-y-3 text-gray-600 text-sm">
-                <li><a href="#" className="hover:text-brand-purple transition-colors">Request a Demo</a></li>
-                <li><a href="#" className="hover:text-brand-purple transition-colors">LinkedIn</a></li>
-             </ul>
+            <h4 className="font-bold text-gray-900 text-sm uppercase tracking-wide">Legal</h4>
+            <ul className="space-y-3 text-gray-600 text-sm">
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Privacy Policy</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Data Security</a></li>
+              <li><a href="#" className="hover:text-brand-purple transition-colors">Terms of Service</a></li>
+            </ul>
           </div>
-          
-           {/* Legal Column - using a new column if space allows or merging */}
-           {/* The previous grid was 6 cols: 2 for brand, 4 for links. We have 5 link categories now.
-               Product, Solutions, Resources, Company, Legal.
-               That needs 5 columns + 2 branding = 7 columns. 
-               Or we can adjust the grid. Let's make it flex or just 6 cols and squeeze?
-               Let's just add Legal under Company or make a new column?
-               Let's stick to the grid. 
-               Let's try to fit Legal in.
-           */}
         </div>
-        
-        {/* Helper for the 5th column if needed, but let's just put Legal next to Company or in a new row if grid wraps */}
-        {/* Actually, I'll just add the Legal header to the grid. The grid is lg:grid-cols-6. 
-            Brand takes 2. Leaves 4. 
-            We have Product, Solutions, Resources, Company, Legal (5 items).
-            One will wrap. That's fine.
-        */}
 
-        {/* Bottom Bar */}
         <div className="flex flex-col md:flex-row justify-between items-center pt-8 border-t border-gray-100 text-sm text-gray-500">
-          <div className="mb-4 md:mb-0">
-            © 2026 Qwalo. All rights reserved.
-          </div>
-          <div className="flex gap-6">
-             <a href="#" className="hover:text-brand-purple transition-colors">Privacy Policy</a>
-          </div>
+          <div className="mb-4 md:mb-0">© 2026 Qwalo. All rights reserved.</div>
         </div>
       </div>
     </footer>

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -1,52 +1,62 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { ChevronDown, Phone } from "lucide-react";
+import { ChevronDown, Menu, X } from "lucide-react";
 import { Link } from "wouter";
 import logoUrl from "@assets/logo.png";
 
+const navGroups = [
+  { name: "Product", items: ["Features", "How It Works", "Languages Supported", "Security"] },
+  { name: "Solutions", items: ["For Marketers", "For Product Managers", "For UX & Research", "For Startups"] },
+  { name: "Resources", items: ["Blog", "Research Playbooks", "FAQs"] }
+];
+
 export function Navbar() {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center pt-6 px-4">
-      <div className="bg-white/95 backdrop-blur-sm rounded-full shadow-sm border border-gray-100 pl-6 pr-2 py-2 flex items-center gap-8 max-w-6xl w-full mx-auto transition-all duration-300">
-        {/* Logo */}
-        <Link href="/" className="flex items-center gap-2 font-bold text-xl tracking-tight text-gray-900 mr-4 cursor-pointer">
-            <img 
-              src={logoUrl} 
-              alt="Qwalo" 
-              className="h-8 w-auto object-contain" 
-            />
+      <div className="relative bg-white/95 backdrop-blur-sm rounded-full lg:rounded-full shadow-sm border border-gray-100 pl-4 lg:pl-6 pr-2 py-2 flex items-center gap-4 lg:gap-8 max-w-6xl w-full mx-auto transition-all duration-300">
+        <Link href="/" className="flex items-center gap-2 font-bold text-xl tracking-tight text-gray-900 cursor-pointer">
+          <img src={logoUrl} alt="Qwalo" className="h-8 w-auto object-contain" />
         </Link>
 
-        {/* Links */}
         <div className="hidden lg:flex items-center gap-6 text-sm font-medium text-gray-600">
-          <button className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
-            Product <ChevronDown className="w-4 h-4 opacity-50" />
-          </button>
-          <button className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
-            Features <ChevronDown className="w-4 h-4 opacity-50" />
-          </button>
-          <button className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
-            Solutions <ChevronDown className="w-4 h-4 opacity-50" />
-          </button>
-          <button className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
-            Integrations <ChevronDown className="w-4 h-4 opacity-50" />
-          </button>
-          <button className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
-            Resources <ChevronDown className="w-4 h-4 opacity-50" />
-          </button>
-          <Link href="/pricing" className="hover:text-brand-purple transition-colors cursor-pointer">Pricing</Link>
+          {navGroups.map((group) => (
+            <button key={group.name} className="flex items-center gap-1 hover:text-brand-purple transition-colors cursor-pointer bg-transparent border-none p-0">
+              {group.name} <ChevronDown className="w-4 h-4 opacity-50" />
+            </button>
+          ))}
         </div>
 
         <div className="flex-1" />
 
-        {/* Actions */}
-        <div className="flex items-center gap-4">
-          <Link href="/demo" className="text-sm font-semibold text-gray-900 hover:text-brand-purple hidden sm:block cursor-pointer">
-              Book demo
+        <button
+          type="button"
+          className="lg:hidden h-10 w-10 rounded-full border border-gray-200 flex items-center justify-center text-gray-700"
+          aria-label="Open navigation menu"
+          onClick={() => setMobileOpen((prev) => !prev)}
+        >
+          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+
+        <div className="hidden lg:flex items-center gap-4">
+          <Link href="/demo" className="text-sm font-semibold text-gray-900 hover:text-brand-purple cursor-pointer">
+            Book demo
           </Link>
           <Button className="bg-brand-purple hover:bg-brand-purple-dark text-white rounded-full px-6 h-10 font-semibold shadow-lg shadow-brand-purple/20 cursor-pointer">
-            Try For Free
+            Start Your Study
           </Button>
         </div>
+
+        {mobileOpen && (
+          <div className="absolute top-[calc(100%+10px)] left-0 right-0 bg-white rounded-2xl border border-gray-100 shadow-lg p-4 lg:hidden">
+            <ul className="space-y-3 text-sm font-medium text-gray-700">
+              {navGroups.map((group) => (
+                <li key={group.name}>{group.name}</li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import { Navbar } from "@/components/layout/Navbar";
 import { Hero } from "@/components/home/Hero";
 import { Features } from "@/components/home/Features";
 import { FAQ } from "@/components/home/FAQ";
+import { HowItWorks } from "@/components/home/HowItWorks";
+import { Solutions } from "@/components/home/Solutions";
 import { Footer } from "@/components/layout/Footer";
 
 export default function Home() {
@@ -11,6 +13,8 @@ export default function Home() {
       <main>
         <Hero />
         <Features />
+        <HowItWorks />
+        <Solutions />
         <FAQ />
       </main>
       <Footer />


### PR DESCRIPTION
### Motivation

- Prevent floating mockup cards from intersecting the hero heading by increasing horizontal padding around the hero content. 
- Provide a compact mobile navigation that keeps the Qwalo logo on the left and exposes Product / Solutions / Resources via a right-side hamburger menu.
- Refresh several home-area UI pieces (mockups, feature cards, FAQ) to better match updated messaging and improve visual clarity.

### Description

- Adjusted the hero content container in `client/src/components/home/Hero.tsx` to increase horizontal padding at `md`/`xl` breakpoints so side mockup cards no longer overlap the main heading. 
- Implemented a mobile hamburger navigation in `client/src/components/layout/Navbar.tsx` with `useState` toggle, a right-side button, and a compact dropdown panel that lists the `Product`, `Solutions`, and `Resources` groups while preserving desktop `lg` layout. 
- Updated mockup and floating card visuals and text in `client/src/components/home/ProductMockups.tsx`, refined features icons and copy in `client/src/components/home/Features.tsx`, and moved/added an FAQ entry in `client/src/components/home/FAQ.tsx`. 
- Added new content sections `HowItWorks` and `Solutions` and updated the site layout to include them via `client/src/pages/Home.tsx`, and reorganized the footer (`client/src/components/layout/Footer.tsx`) with adjusted columns and a LinkedIn link.

### Testing

- Ran a production build using `npm run build` which completed successfully. 
- Started the dev server with `npm run dev` and executed an automated Playwright script that captured screenshots for desktop hero spacing and the mobile navbar menu (`hero-desktop-fixed.png` and `navbar-mobile-menu.png`), both of which were produced without errors. 
- No automated test failures were observed during the build and UI checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd03d313883289c71c958500ac4ea)