### PR TITLE
Add concise README and improve dashboard workspace navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Qwalo Website
+
+Frontend web app for Qwalo, built with React + Vite + TypeScript.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 10+
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The app runs on `http://localhost:5173` by default.
+
+## Environment variables
+
+Create a `.env` file in the project root when needed.
+
+```bash
+VITE_CLERK_PUBLISHABLE_KEY=your_clerk_key
+```
+
+- If `VITE_CLERK_PUBLISHABLE_KEY` is set, Clerk authentication pages are enabled.
+- If missing, auth routes render a fallback `AuthNotConfigured` page.
+
+## Scripts
+
+- `npm run dev` — start local dev server
+- `npm run build` — create production build
+- `npm run preview` — preview production build locally
+- `npm run check` — run TypeScript type checks
+
+## Main routes
+
+- `/` — landing page
+- `/sign-up`, `/sign-in`, `/waitlist`, `/sso-callback` — auth flow (Clerk-enabled)
+- `/dashboard` — workspace dashboard
+- `/dashboard/workspaces/:id` — workspace detail
+
+## Tech stack
+
+- React 19
+- TypeScript
+- Vite
+- Wouter (routing)
+- TanStack Query
+- Tailwind CSS + Radix UI
+- Clerk (optional auth)

--- a/client/src/components/dashboard/DashboardLayout.tsx
+++ b/client/src/components/dashboard/DashboardLayout.tsx
@@ -2,22 +2,27 @@ import { Link, useLocation } from "wouter";
 import { ReactNode, useMemo, useState } from "react";
 import logoUrl from "@assets/logo.png";
 import { Button } from "@/components/ui/button";
-import { LayoutDashboard, LogOut, PanelLeftClose, PanelLeftOpen, Building2 } from "lucide-react";
+import { LayoutDashboard, LogOut, PanelLeftClose, PanelLeftOpen, Building2, FolderKanban } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface DashboardLayoutProps {
   children: ReactNode;
   /** Organization/workspace name shown in header when inside a workspace */
   organizationName?: string | null;
+  /** Current workspace context for sidebar navigation */
+  workspaceName?: string | null;
+  workspaceId?: string | null;
 }
 
 /**
  * Wraps dashboard pages with consistent layout and nav.
  */
-export function DashboardLayout({ children, organizationName }: DashboardLayoutProps) {
+export function DashboardLayout({ children, organizationName, workspaceName, workspaceId }: DashboardLayoutProps) {
   const [location] = useLocation();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const isDashboardRoot = location === "/dashboard" || location === "/dashboard/";
+  const workspaceHref = workspaceId ? `/dashboard/workspaces/${workspaceId}` : null;
+  const isWorkspacePage = Boolean(workspaceHref && location === workspaceHref);
 
   const navItems = useMemo(
     () => [
@@ -27,8 +32,18 @@ export function DashboardLayout({ children, organizationName }: DashboardLayoutP
         icon: LayoutDashboard,
         isActive: isDashboardRoot,
       },
+      ...(workspaceHref && workspaceName
+        ? [
+            {
+              href: workspaceHref,
+              label: workspaceName,
+              icon: FolderKanban,
+              isActive: isWorkspacePage,
+            },
+          ]
+        : []),
     ],
-    [isDashboardRoot]
+    [isDashboardRoot, isWorkspacePage, workspaceHref, workspaceName]
   );
 
   return (

--- a/client/src/pages/dashboard/WorkspaceDetail.tsx
+++ b/client/src/pages/dashboard/WorkspaceDetail.tsx
@@ -210,7 +210,11 @@ export default function WorkspaceDetail() {
   };
 
   return (
-    <DashboardLayout organizationName={workspace.organizationName}>
+    <DashboardLayout
+      organizationName={workspace.organizationName}
+      workspaceName={workspace.name}
+      workspaceId={workspace.id}
+    >
       <div className="space-y-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>


### PR DESCRIPTION
### Motivation

- Provide a minimal, focused project `README.md` so developers can quickly set up and understand the app.
- Surface current workspace context in the dashboard layout so navigation highlights and links reflect the active workspace.

### Description

- Added a root `README.md` containing prerequisites, quick start (`npm install` / `npm run dev`), environment variables (notably `VITE_CLERK_PUBLISHABLE_KEY`), available scripts, main routes, and core tech stack.
- Extended `DashboardLayout` to accept `workspaceName` and `workspaceId` props, compute `workspaceHref`/`isWorkspacePage`, import `FolderKanban` icon, and include the workspace as a dynamic nav item; updated `useMemo` deps accordingly.
- Updated `WorkspaceDetail` to pass `organizationName`, `workspaceName`, and `workspaceId` into `DashboardLayout` so the sidebar and active state reflect the opened workspace.

### Testing

- Ran TypeScript checks with `npm run check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69969e5d63f88328b2fe2b13dddea5db)